### PR TITLE
Adjust radicality penalty for early/late Ascendant

### DIFF
--- a/backend/horary_constants.yaml
+++ b/backend/horary_constants.yaml
@@ -131,6 +131,7 @@ radicality:
   via_combusta_enabled: true # check Moon in Via Combusta
   hour_agreement_enabled: false # check planetary hour agreement
   hour_agreement_mode: "ruler"  # options: ruler, sign, triplicity
+  asc_warning_penalty: 15  # Confidence penalty for early or late Ascendant warnings
 
   via_combusta:
     libra_start: 15.0    # degrees into Libra

--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -1086,7 +1086,13 @@ class EnhancedTraditionalHoraryJudgmentEngine:
             radicality = check_enhanced_radicality(chart, ignore_saturn_7th)
             if not radicality["valid"]:
                 reasoning.append(f"⚠️ Radicality: {radicality['reason']}")
-                confidence = min(confidence, config.confidence.lunar_confidence_caps.neutral)
+                reason = radicality["reason"]
+                # Early or late Ascendant only gives a modest penalty
+                if "Ascendant too early" in reason or "Ascendant too late" in reason:
+                    penalty = getattr(config.radicality, "asc_warning_penalty", 15)
+                    confidence = max(confidence - penalty, 0)
+                else:
+                    confidence = min(confidence, config.confidence.lunar_confidence_caps.neutral)
             else:
                 reasoning.append(f"Radicality: {radicality['reason']}")
         else:

--- a/backend/tests/test_consideration_warnings.py
+++ b/backend/tests/test_consideration_warnings.py
@@ -42,7 +42,17 @@ def patch_engine_for_tests(engine, monkeypatch):
         return {"valid": True, "querent": Planet.MERCURY, "quesited": Planet.JUPITER, "description": "Mercury-Jupiter"}
     monkeypatch.setattr(engine, "_identify_significators", fake_identify_significators)
     monkeypatch.setattr(engine, "_analyze_enhanced_solar_factors", lambda *a, **k: {"significant": False})
-    monkeypatch.setattr(engine, "_check_enhanced_perfection", lambda *a, **k: {"perfects": True, "favorable": True, "confidence": 80, "type": "direct", "reason": "test"})
+    monkeypatch.setattr(
+        engine,
+        "_check_enhanced_perfection",
+        lambda *a, **k: {
+            "perfects": True,
+            "favorable": True,
+            "confidence": cfg().confidence.perfection.direct_basic,
+            "type": "direct",
+            "reason": "test",
+        },
+    )
     monkeypatch.setattr(engine, "_apply_aspect_direction_adjustment", lambda c, p, r: c)
     monkeypatch.setattr(engine, "_apply_dignity_confidence_adjustment", lambda c, ch, q, qs, r: c)
     monkeypatch.setattr(engine, "_apply_retrograde_quesited_penalty", lambda c, ch, q, r: c)
@@ -64,7 +74,11 @@ def test_non_radical_chart_still_returns(monkeypatch):
 
     assert result["result"] == "YES"
     assert any("Ascendant" in r for r in result["reasoning"])
-    assert result["confidence"] == cfg().confidence.lunar_confidence_caps.neutral
+    expected_confidence = min(
+        cfg().confidence.base_confidence - cfg().radicality.asc_warning_penalty,
+        cfg().confidence.perfection.direct_basic,
+    )
+    assert result["confidence"] == expected_confidence
 
 
 def test_void_moon_chart_still_returns(monkeypatch):


### PR DESCRIPTION
## Summary
- Use a configurable penalty instead of a hard cap when radicality fails due to early or late Ascendant.
- Add `asc_warning_penalty` to `radicality` settings.
- Update consideration warning tests for the new confidence behavior.

## Testing
- `pytest tests/test_consideration_warnings.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ec52075508324b96eb44e4d289740