### PR TITLE
Make retrograde penalty configurable and mitigable

### DIFF
--- a/backend/horary_constants.yaml
+++ b/backend/horary_constants.yaml
@@ -159,6 +159,7 @@ retrograde:
   automatic_denial: false  # Don't automatically deny for retrograde
   dignity_penalty: -2     # Penalty for retrograde significator
   frustration_penalty: -5 # Additional penalty for retrograde frustration
+  quesited_penalty: 12    # Confidence penalty for retrograde quesited (mitigable)
 
 reception:
   terms:

--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -1312,11 +1312,11 @@ class EnhancedTraditionalHoraryJudgmentEngine:
             # CRITICAL FIX 1: Apply separating aspect penalty
             confidence = self._apply_aspect_direction_adjustment(confidence, perfection, reasoning)
             
-            # CRITICAL FIX 2: Apply dignity-based confidence adjustment
-            confidence = self._apply_dignity_confidence_adjustment(confidence, chart, querent_planet, quesited_planet, reasoning)
-            
-            # CRITICAL FIX 3: Apply retrograde quesited penalty
+            # CRITICAL FIX 2: Apply retrograde quesited penalty early so bonuses can offset it
             confidence = self._apply_retrograde_quesited_penalty(confidence, chart, quesited_planet, reasoning)
+
+            # CRITICAL FIX 3: Apply dignity-based confidence adjustment (can mitigate retrograde)
+            confidence = self._apply_dignity_confidence_adjustment(confidence, chart, querent_planet, quesited_planet, reasoning)
             
             # Clear step-by-step traditional reasoning
             if perfection["type"] == "direct_denied":
@@ -1879,17 +1879,18 @@ class EnhancedTraditionalHoraryJudgmentEngine:
             
         return confidence
     
-    def _apply_retrograde_quesited_penalty(self, confidence: float, chart: HoraryChart, 
+    def _apply_retrograde_quesited_penalty(self, confidence: float, chart: HoraryChart,
                                          quesited: Planet, reasoning: List[str]) -> float:
-        """CRITICAL FIX 3: Apply penalty for retrograde quesited"""
-        
+        """CRITICAL FIX 2: Apply penalty for retrograde quesited"""
+
+        config = cfg()
         quesited_pos = chart.planets[quesited]
         if quesited_pos.retrograde:
             # Retrograde quesited = turning away, obstacles, delays
-            penalty = 25
+            penalty = getattr(config.retrograde, "quesited_penalty", 12)
             confidence = max(confidence - penalty, 10)
             reasoning.append(f"🔴 Retrograde quesited: -{penalty}% (turning away from success)")
-            
+
         return confidence
     
     def _check_enhanced_translation_of_light(self, chart: HoraryChart, querent: Planet, quesited: Planet) -> Dict[str, Any]:

--- a/backend/tests/test_retrograde_penalty.py
+++ b/backend/tests/test_retrograde_penalty.py
@@ -1,0 +1,50 @@
+import datetime
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from horary_config import cfg
+from horary_engine.engine import EnhancedTraditionalHoraryJudgmentEngine
+from models import HoraryChart, Planet, Sign, PlanetPosition
+
+
+def make_chart():
+    now = datetime.datetime.utcnow()
+    planets = {
+        Planet.MARS: PlanetPosition(Planet.MARS, 0, 0, 1, Sign.ARIES, 0),
+        Planet.MERCURY: PlanetPosition(Planet.MERCURY, 0, 0, 7, Sign.GEMINI, 12, True),
+    }
+    houses = [i * 30 for i in range(12)]
+    house_rulers = {1: Planet.MARS, 7: Planet.MERCURY}
+    return HoraryChart(
+        date_time=now,
+        date_time_utc=now,
+        timezone_info="UTC",
+        location=(0.0, 0.0),
+        location_name="Test",
+        planets=planets,
+        aspects=[],
+        houses=houses,
+        house_rulers=house_rulers,
+        ascendant=0.0,
+        midheaven=0.0,
+    )
+
+
+def test_retrograde_penalty_configurable_and_offset_by_dignity():
+    engine = EnhancedTraditionalHoraryJudgmentEngine()
+    chart = make_chart()
+    reasoning = []
+    base_confidence = 80
+
+    original_penalty = cfg().retrograde.quesited_penalty
+    try:
+        cfg().retrograde.quesited_penalty = 12
+        confidence = engine._apply_retrograde_quesited_penalty(base_confidence, chart, Planet.MERCURY, reasoning)
+        assert confidence == base_confidence - 12
+
+        confidence = engine._apply_dignity_confidence_adjustment(confidence, chart, Planet.MARS, Planet.MERCURY, reasoning)
+        assert confidence == base_confidence - 12 + 15
+    finally:
+        cfg().retrograde.quesited_penalty = original_penalty


### PR DESCRIPTION
## Summary
- add `retrograde.quesited_penalty` config with default 12
- have `_apply_retrograde_quesited_penalty` use config and run before dignity adjustment so bonuses can offset
- test configurable penalty and dignity mitigation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ec52f2bd08324accef4ef978d54ec