### PR TITLE
Handle low-confidence perfection without auto-denial

### DIFF
--- a/backend/tests/test_confidence_threshold.py
+++ b/backend/tests/test_confidence_threshold.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from horary_engine.engine import EnhancedTraditionalHoraryJudgmentEngine
+
+
+def test_yes_confidence_below_30_is_inconclusive():
+    engine = EnhancedTraditionalHoraryJudgmentEngine()
+    reasoning = []
+    result, conf = engine._apply_confidence_threshold("YES", 25, reasoning)
+    assert result == "INCONCLUSIVE"
+    assert conf == 25
+    assert any("Very low confidence" in r for r in reasoning)
+
+
+def test_yes_confidence_between_30_and_50_remains_yes_with_warning():
+    engine = EnhancedTraditionalHoraryJudgmentEngine()
+    reasoning = []
+    result, conf = engine._apply_confidence_threshold("YES", 40, reasoning)
+    assert result == "YES"
+    assert conf == 40
+    assert any("Low confidence" in r for r in reasoning)


### PR DESCRIPTION
## Summary
- Prevent automatic NO for low-confidence YES results
- Warn or mark inconclusive when confidence is below threshold
- Add tests for updated confidence threshold behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ec5594124832483ce7a83a1236978