### PR TITLE
Compute Sun altitude for combustion exceptions

### DIFF
--- a/backend/horary_engine/calculation/helpers.py
+++ b/backend/horary_engine/calculation/helpers.py
@@ -242,22 +242,32 @@ def sun_altitude_at_civil_twilight(latitude: float, longitude: float,
     
     Returns:
         Sun's altitude in degrees (negative below horizon)
-    
+
     Classical source: Al-Biruni - planetary visibility and heliacal risings
     """
     try:
-        # Calculate Sun position
+        # Calculate ecliptic position of the Sun
         sun_data, _ = swe.calc_ut(jd_ut, swe.SUN, swe.FLG_SWIEPH)
         sun_longitude = sun_data[0]
         sun_latitude = sun_data[1]
-        
-        # Convert to horizontal coordinates would require more complex calc
-        # For simplicity, approximate using -8° as civil twilight threshold
-        # This is the classical threshold used in traditional astrology
-        return -8.0  # Standard civil twilight altitude
-        
+        sun_distance = sun_data[2]
+
+        # Convert ecliptic coordinates to altitude/azimuth
+        geopos = (longitude, latitude, 0)  # Observer position (east positive)
+        _, altitude, _ = swe.azalt(
+            jd_ut,
+            swe.ECL2HOR,
+            geopos,
+            0,  # Atmospheric pressure (ignored)
+            0,  # Atmospheric temperature (ignored)
+            (sun_longitude, sun_latitude, sun_distance),
+        )
+
+        return float(altitude)
+
     except Exception:
-        return -8.0  # Default to civil twilight
+        # Fallback to classical civil twilight threshold
+        return -8.0
 
 
 def calculate_moon_variable_speed(jd_ut: float) -> float:

--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -358,13 +358,14 @@ class EnhancedTraditionalAstrologicalCalculator:
         
         # Classical visibility conditions
         if planet == Planet.MERCURY:
-            # Mercury rejoices near Sun but needs visibility
-            if elongation >= 10.0 and planet_pos.sign in [Sign.GEMINI, Sign.VIRGO]:
-                return True
-            # Or if greater elongation (18° for Mercury)
-            if elongation >= 18.0:
-                return True
-                
+            # Mercury rejoices near Sun but still requires the Sun to be below the horizon
+            if sun_altitude <= -8.0:
+                if elongation >= 10.0 and planet_pos.sign in [Sign.GEMINI, Sign.VIRGO]:
+                    return True
+                # Or if greater elongation (18° for Mercury)
+                if elongation >= 18.0:
+                    return True
+
         elif planet == Planet.VENUS:
             # Venus as morning/evening star exception
             if elongation >= 10.0:  # Minimum visibility

--- a/backend/tests/test_combustion_visibility.py
+++ b/backend/tests/test_combustion_visibility.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import swisseph as swe
+from horary_engine.engine import EnhancedTraditionalAstrologicalCalculator
+from models import Planet, PlanetPosition, Sign
+
+
+def _pos(planet, lon, sign):
+    return PlanetPosition(planet=planet, longitude=lon, latitude=0.0, house=1, sign=sign, dignity_score=0)
+
+
+def test_mercury_exception_requires_darkness():
+    engine = EnhancedTraditionalAstrologicalCalculator()
+    lat = 0.0
+    lon = 0.0
+    jd_day = swe.julday(2024, 6, 21, 12.0)
+    jd_night = swe.julday(2024, 6, 21, 0.0)
+
+    mercury_pos = _pos(Planet.MERCURY, 80.0, Sign.GEMINI)  # 20° Gemini
+    sun_pos = _pos(Planet.SUN, 60.0, Sign.GEMINI)  # 0° Gemini
+
+    assert not engine._check_enhanced_combustion_exception(Planet.MERCURY, mercury_pos, sun_pos, lat, lon, jd_day)
+    assert engine._check_enhanced_combustion_exception(Planet.MERCURY, mercury_pos, sun_pos, lat, lon, jd_night)
+
+
+def test_venus_exception_requires_darkness():
+    engine = EnhancedTraditionalAstrologicalCalculator()
+    lat = 0.0
+    lon = 0.0
+    jd_day = swe.julday(2024, 6, 21, 12.0)
+    jd_night = swe.julday(2024, 6, 21, 0.0)
+
+    venus_pos = _pos(Planet.VENUS, 80.0, Sign.GEMINI)
+    sun_pos = _pos(Planet.SUN, 60.0, Sign.GEMINI)
+
+    assert not engine._check_enhanced_combustion_exception(Planet.VENUS, venus_pos, sun_pos, lat, lon, jd_day)
+    assert engine._check_enhanced_combustion_exception(Planet.VENUS, venus_pos, sun_pos, lat, lon, jd_night)


### PR DESCRIPTION
## Summary
- Calculate true Sun altitude using Swiss Ephemeris instead of a placeholder value
- Require Sun below horizon for Mercury and Venus combustion exceptions
- Test Venus and Mercury visibility behavior at day vs night

## Testing
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689ec96b842c8324b608376d5648ff08