### PR TITLE
Respect planetary motion in lunar aspects

### DIFF
--- a/backend/horary_engine/aspects.py
+++ b/backend/horary_engine/aspects.py
@@ -100,10 +100,10 @@ def calculate_moon_next_aspect(
                     moon_pos, planet_pos, aspect_type, moon_speed
                 ):
                     degrees_to_exact = orb_diff
-                    relative_speed = abs(moon_speed - abs(planet_pos.speed))
+                    relative_speed = moon_speed - planet_pos.speed
                     time_to_exact = (
-                        degrees_to_exact / relative_speed
-                        if relative_speed > 0
+                        degrees_to_exact / abs(relative_speed)
+                        if relative_speed != 0
                         else float("inf")
                     )
 
@@ -142,9 +142,12 @@ def is_moon_separating_from_aspect(
     if current_separation > 180:
         current_separation = 360 - current_separation
 
-    # Future Moon position
+    # Future positions considering both bodies' motion
     future_moon_lon = (moon_pos.longitude + moon_speed * time_increment) % 360
-    future_separation = abs(future_moon_lon - planet_pos.longitude)
+    future_planet_lon = (
+        planet_pos.longitude + planet_pos.speed * time_increment
+    ) % 360
+    future_separation = abs(future_moon_lon - future_planet_lon)
     if future_separation > 180:
         future_separation = 360 - future_separation
 
@@ -169,9 +172,12 @@ def is_moon_applying_to_aspect(
     if current_separation > 180:
         current_separation = 360 - current_separation
 
-    # Future Moon position
+    # Future positions considering both bodies' motion
     future_moon_lon = (moon_pos.longitude + moon_speed * time_increment) % 360
-    future_separation = abs(future_moon_lon - planet_pos.longitude)
+    future_planet_lon = (
+        planet_pos.longitude + planet_pos.speed * time_increment
+    ) % 360
+    future_separation = abs(future_moon_lon - future_planet_lon)
     if future_separation > 180:
         future_separation = 360 - future_separation
 

--- a/backend/tests/test_moon_aspects.py
+++ b/backend/tests/test_moon_aspects.py
@@ -1,0 +1,62 @@
+import pytest
+from models import Planet, PlanetPosition, Sign, Aspect
+from horary_engine.aspects import (
+    calculate_moon_next_aspect,
+    is_moon_applying_to_aspect,
+    is_moon_separating_from_aspect,
+)
+
+
+def make_planet_position(planet, lon, speed, retrograde=False):
+    return PlanetPosition(
+        planet=planet,
+        longitude=lon,
+        latitude=0.0,
+        house=1,
+        sign=Sign.ARIES,
+        dignity_score=0,
+        retrograde=retrograde,
+        speed=speed,
+    )
+
+
+def test_calculate_moon_next_aspect_timing_direct_and_retrograde():
+    moon = make_planet_position(Planet.MOON, 10.0, 12.0)
+    get_speed = lambda jd: moon.speed
+
+    direct_planet = make_planet_position(Planet.MERCURY, 15.0, 1.0)
+    planets = {Planet.MOON: moon, Planet.MERCURY: direct_planet}
+    aspect = calculate_moon_next_aspect(planets, 0.0, get_speed)
+    assert aspect is not None
+    assert aspect.aspect == Aspect.CONJUNCTION
+    assert aspect.applying
+    assert aspect.perfection_eta_days == pytest.approx(5.0 / 11.0, rel=1e-3)
+
+    retro_planet = make_planet_position(Planet.MERCURY, 15.0, -1.0, retrograde=True)
+    planets = {Planet.MOON: moon, Planet.MERCURY: retro_planet}
+    aspect = calculate_moon_next_aspect(planets, 0.0, get_speed)
+    assert aspect is not None
+    assert aspect.aspect == Aspect.CONJUNCTION
+    assert aspect.applying
+    assert aspect.perfection_eta_days == pytest.approx(5.0 / 13.0, rel=1e-3)
+
+
+def test_application_and_separation_detection():
+    moon_speed = 12.0
+    moon = make_planet_position(Planet.MOON, 10.0, moon_speed)
+    aspect = Aspect.CONJUNCTION
+
+    direct_app = make_planet_position(Planet.MERCURY, 15.0, 1.0)
+    assert is_moon_applying_to_aspect(moon, direct_app, aspect, moon_speed)
+
+    direct_sep = make_planet_position(Planet.MERCURY, 5.0, 1.0)
+    assert not is_moon_applying_to_aspect(moon, direct_sep, aspect, moon_speed)
+    assert is_moon_separating_from_aspect(moon, direct_sep, aspect, moon_speed)
+
+    retro_app = make_planet_position(Planet.MERCURY, 15.0, -1.0, retrograde=True)
+    assert is_moon_applying_to_aspect(moon, retro_app, aspect, moon_speed)
+
+    retro_sep = make_planet_position(Planet.MERCURY, 5.0, -1.0, retrograde=True)
+    assert not is_moon_applying_to_aspect(moon, retro_sep, aspect, moon_speed)
+    assert is_moon_separating_from_aspect(moon, retro_sep, aspect, moon_speed)
+


### PR DESCRIPTION
## Summary
- compute lunar aspect timing using signed relative speed
- factor planet motion into applying/separating Moon checks
- test direct and retrograde Moon aspects for timing and application/separation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ec98cdeb083248713c2a55109349d