### PR TITLE
Clean up horary config tail and add logging test

### DIFF
--- a/backend/horary_config.py
+++ b/backend/horary_config.py
@@ -174,10 +174,5 @@ if os.environ.get('HORARY_CONFIG_SKIP_VALIDATION') != 'true':
         get_config().validate_required_keys()
     except HoraryError as e:
         logger.error(f"Configuration validation failed: {e}")
-        # Don't raise here to allow module import - let individual functions handle missing config# -*- coding: utf-8 -*-
-"""
-Spyder Editor
-
-This is a temporary script file.
-"""
+        # Don't raise here to allow module import - let individual functions handle missing config
 

--- a/backend/tests/test_horary_config.py
+++ b/backend/tests/test_horary_config.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import logging
+
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from horary_config import HoraryConfig
+
+
+def test_horary_config_loads_without_unexpected_logs(caplog):
+    HoraryConfig.reset()
+    with caplog.at_level(logging.INFO, logger="horary_config"):
+        cfg = HoraryConfig()
+        assert cfg.config is not None
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message.startswith("Loaded horary configuration")
+


### PR DESCRIPTION
## Summary
- remove stray Spyder text at end of `horary_config.py`
- add regression test ensuring `HoraryConfig` logs only the expected load message

## Testing
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_689ec991fa8483249f42629633076d1c