### PR TITLE
Require aspect for mutual reception

### DIFF
--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -2976,21 +2976,21 @@ class EnhancedTraditionalHoraryJudgmentEngine:
         reception = self._check_enhanced_mutual_reception(chart, querent, quesited)
         if reception == "mutual_rulership":
             return {
-                "perfects": True,
+                "perfects": False,
                 "type": "reception",
                 "favorable": True,
                 "confidence": config.confidence.perfection.reception_only,
-                "reason": f"Reception: {self._format_reception_for_display(reception, querent, quesited, chart)} - unconditional perfection",
+                "reason": f"Reception: {self._format_reception_for_display(reception, querent, quesited, chart)} - needs aspect or translation",
                 "reception": reception
             }
         elif reception == "mutual_exaltation":
             boosted_confidence = min(100, config.confidence.perfection.reception_only + exaltation_confidence_boost)
             return {
-                "perfects": True,
+                "perfects": False,
                 "type": "reception",
                 "favorable": True,
                 "confidence": int(boosted_confidence),
-                "reason": f"Reception: {self._format_reception_for_display(reception, querent, quesited, chart)} (+{exaltation_confidence_boost}% confidence)",
+                "reason": f"Reception: {self._format_reception_for_display(reception, querent, quesited, chart)} (+{exaltation_confidence_boost}% confidence) - needs aspect or translation",
                 "reception": reception
             }
         

--- a/backend/tests/test_mutual_reception_no_connection.py
+++ b/backend/tests/test_mutual_reception_no_connection.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import datetime
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from horary_engine import engine as engine_module
+from horary_engine.engine import EnhancedTraditionalHoraryJudgmentEngine
+from models import HoraryChart, Planet, Sign, PlanetPosition
+
+
+def make_chart():
+    now = datetime.datetime.utcnow()
+    planets = {
+        Planet.MERCURY: PlanetPosition(Planet.MERCURY, 0, 0, 1, Sign.SAGITTARIUS, 0),
+        Planet.JUPITER: PlanetPosition(Planet.JUPITER, 0, 0, 7, Sign.GEMINI, 0),
+        Planet.SUN: PlanetPosition(Planet.SUN, 0, 0, 4, Sign.CANCER, 0),
+        Planet.MOON: PlanetPosition(Planet.MOON, 0, 0, 3, Sign.ARIES, 0),
+    }
+    houses = [i * 30 for i in range(12)]
+    house_rulers = {1: Planet.MERCURY, 7: Planet.JUPITER}
+    return HoraryChart(
+        date_time=now,
+        date_time_utc=now,
+        timezone_info="UTC",
+        location=(0.0, 0.0),
+        location_name="Test",
+        planets=planets,
+        aspects=[],
+        houses=houses,
+        house_rulers=house_rulers,
+        ascendant=0.0,
+        midheaven=0.0,
+    )
+
+
+def test_mutual_reception_without_connection(monkeypatch):
+    engine = EnhancedTraditionalHoraryJudgmentEngine()
+    chart = make_chart()
+
+    def fake_identify_significators(chart, qa):
+        return {
+            "valid": True,
+            "querent": Planet.MERCURY,
+            "quesited": Planet.JUPITER,
+            "description": "Mercury-Jupiter",
+        }
+
+    monkeypatch.setattr(engine, "_identify_significators", fake_identify_significators)
+    monkeypatch.setattr(
+        engine_module,
+        "check_enhanced_radicality",
+        lambda c, ignore=False: {"valid": True, "reason": "radical"},
+    )
+    monkeypatch.setattr(
+        engine,
+        "_is_moon_void_of_course_enhanced",
+        lambda c: {"void": False, "exception": False, "reason": ""},
+    )
+    monkeypatch.setattr(
+        engine,
+        "_analyze_enhanced_solar_factors",
+        lambda *a, **k: {"significant": False},
+    )
+    monkeypatch.setattr(engine, "_apply_aspect_direction_adjustment", lambda c, p, r: c)
+    monkeypatch.setattr(engine, "_apply_dignity_confidence_adjustment", lambda c, ch, q, qs, r: c)
+    monkeypatch.setattr(engine, "_apply_retrograde_quesited_penalty", lambda c, ch, q, r: c)
+    monkeypatch.setattr(engine, "_calculate_enhanced_timing", lambda *a, **k: None)
+    monkeypatch.setattr(engine, "_check_enhanced_moon_testimony", lambda *a, **k: {})
+    monkeypatch.setattr(engine, "_check_enhanced_denial_conditions", lambda *a, **k: {"denied": False})
+    monkeypatch.setattr(engine, "_check_moon_next_aspect_to_significators", lambda *a, **k: {"decisive": False})
+    monkeypatch.setattr(engine, "_check_benefic_aspects_to_significators", lambda *a, **k: {"favorable": False})
+
+    perfection = engine._check_enhanced_perfection(chart, Planet.MERCURY, Planet.JUPITER)
+    assert perfection["reception"] == "mutual_rulership"
+    assert not perfection["perfects"]
+
+    result = engine._apply_enhanced_judgment(chart, {})
+    assert result["result"] == "NO"
+


### PR DESCRIPTION
## Summary
- Prevent mutual reception alone from perfecting by returning `perfects: False`
- Add regression test ensuring mutual reception without aspect cannot produce a YES verdict

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eeff141ec83248d546f56eae676c4