### PR TITLE
Use timing for prohibition checks

### DIFF
--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -3149,7 +3149,12 @@ class EnhancedTraditionalHoraryJudgmentEngine:
         direct_aspect = self._find_applying_aspect(chart, querent, quesited)
         if not direct_aspect:
             return {"found": False}  # No pending perfection = no prohibition possible
-        
+
+        # Calculate timing for the main perfection
+        querent_pos = chart.planets[querent]
+        quesited_pos = chart.planets[quesited]
+        main_perfection_days = self._days_to_aspect_perfection(querent_pos, quesited_pos, direct_aspect)
+
         # TRADITIONAL REQUIREMENT 2: Check if any third planet completes aspect first
         for aspect in chart.aspects:
             if not aspect.applying:
@@ -3169,7 +3174,15 @@ class EnhancedTraditionalHoraryJudgmentEngine:
                 continue  # Not a prohibition scenario
             
             # TRADITIONAL REQUIREMENT 3: Prohibiting aspect must complete before significator perfection
-            if aspect.degrees_to_exact < direct_aspect["degrees_to_exact"]:
+            prohibiting_pos = chart.planets[prohibiting_planet]
+            target_pos = chart.planets[target_significator]
+            prohibiting_days = self._days_to_aspect_perfection(
+                target_pos,
+                prohibiting_pos,
+                {"degrees_to_exact": aspect.degrees_to_exact},
+            )
+
+            if prohibiting_days < main_perfection_days:
                 
                 # Assess severity based on prohibiting planet
                 base_confidence = config.confidence.denial.prohibition

--- a/backend/tests/test_traditional_prohibition.py
+++ b/backend/tests/test_traditional_prohibition.py
@@ -1,0 +1,60 @@
+import datetime
+
+import pytest
+
+from horary_engine.engine import EnhancedTraditionalHoraryJudgmentEngine
+from models import (
+    Aspect,
+    AspectInfo,
+    HoraryChart,
+    Planet,
+    PlanetPosition,
+    Sign,
+)
+
+
+def test_later_aspect_does_not_prohibit():
+    now = datetime.datetime.utcnow()
+    planets = {
+        Planet.MERCURY: PlanetPosition(Planet.MERCURY, 0, 0, 1, Sign.ARIES, 0, False, 1.0),
+        Planet.JUPITER: PlanetPosition(Planet.JUPITER, 0, 0, 7, Sign.LIBRA, 0, False, 0.5),
+        Planet.SATURN: PlanetPosition(Planet.SATURN, 0, 0, 4, Sign.CAPRICORN, 0, False, 0.4),
+    }
+
+    direct = AspectInfo(
+        planet1=Planet.MERCURY,
+        planet2=Planet.JUPITER,
+        aspect=Aspect.CONJUNCTION,
+        orb=5.0,
+        applying=True,
+        degrees_to_exact=5.0,
+    )
+
+    prohibiting = AspectInfo(
+        planet1=Planet.JUPITER,
+        planet2=Planet.SATURN,
+        aspect=Aspect.CONJUNCTION,
+        orb=5.0,
+        applying=True,
+        degrees_to_exact=4.0,
+    )
+
+    chart = HoraryChart(
+        date_time=now,
+        date_time_utc=now,
+        timezone_info="UTC",
+        location=(0.0, 0.0),
+        location_name="Test",
+        planets=planets,
+        aspects=[direct, prohibiting],
+        houses=[i * 30 for i in range(12)],
+        house_rulers={1: Planet.MERCURY, 7: Planet.JUPITER},
+        ascendant=0.0,
+        midheaven=0.0,
+    )
+
+    engine = EnhancedTraditionalHoraryJudgmentEngine()
+    engine._check_dignified_reception = lambda *a, **k: False
+
+    result = engine._check_traditional_prohibition(chart, Planet.MERCURY, Planet.JUPITER)
+    assert result["found"] is False


### PR DESCRIPTION
## Summary
- Compute days to perfection for main and candidate aspects in `_check_traditional_prohibition`
- Compare prohibiting aspects using time-based perfection rather than degrees
- Add regression test ensuring slower aspects cannot prohibit earlier perfection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ef003f4b08324b647ebf3fbb26ed9