### PR TITLE
Check station timing before aspect perfection

### DIFF
--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -3224,20 +3224,35 @@ class EnhancedTraditionalHoraryJudgmentEngine:
         # Use enhanced sign exit calculations
         days_to_exit_1 = days_to_sign_exit(pos1.longitude, pos1.speed)
         days_to_exit_2 = days_to_sign_exit(pos2.longitude, pos2.speed)
-        
+
         # Estimate days until aspect perfects
         relative_speed = abs(pos1.speed - pos2.speed)
         if relative_speed == 0:
             return False
-        
+
         days_to_perfect = aspect_info["degrees_to_exact"] / relative_speed
-        
+
+        # NEW: Check for future stations before perfection
+        jd_start = chart.julian_day
+        planet_id_1 = self.calculator.planets_swe.get(pos1.planet)
+        planet_id_2 = self.calculator.planets_swe.get(pos2.planet)
+
+        if planet_id_1 is not None:
+            station_jd_1 = calculate_next_station_time(planet_id_1, jd_start)
+            if station_jd_1 and (station_jd_1 - jd_start) < days_to_perfect:
+                return False
+
+        if planet_id_2 is not None:
+            station_jd_2 = calculate_next_station_time(planet_id_2, jd_start)
+            if station_jd_2 and (station_jd_2 - jd_start) < days_to_perfect:
+                return False
+
         # Check if either planet exits sign before perfection
         if days_to_exit_1 and days_to_perfect > days_to_exit_1:
             return False
         if days_to_exit_2 and days_to_perfect > days_to_exit_2:
             return False
-        
+
         return True
     
     def _check_enhanced_mutual_reception(self, chart: HoraryChart, planet1: Planet, planet2: Planet) -> str:

--- a/backend/tests/test_station_perfection.py
+++ b/backend/tests/test_station_perfection.py
@@ -1,0 +1,68 @@
+import sys
+import os
+import datetime
+
+from hypothesis import given, strategies as st, settings, HealthCheck
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import horary_engine.engine as engine_module
+from horary_engine.engine import EnhancedTraditionalHoraryJudgmentEngine
+from models import Planet, Sign, PlanetPosition, HoraryChart
+
+
+@settings(deadline=None, max_examples=20, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(st.floats(min_value=0.1, max_value=50.0))
+def test_station_after_perfection_does_not_deny(monkeypatch, extra_days):
+    """A station after aspect perfection should not cause denial."""
+
+    engine = EnhancedTraditionalHoraryJudgmentEngine()
+
+    # Simple planet positions with known relative speed
+    pos1 = PlanetPosition(
+        planet=Planet.MARS,
+        longitude=10.0,
+        latitude=0.0,
+        house=1,
+        sign=Sign.ARIES,
+        dignity_score=0,
+        retrograde=False,
+        speed=1.0,
+    )
+    pos2 = PlanetPosition(
+        planet=Planet.VENUS,
+        longitude=15.0,
+        latitude=0.0,
+        house=7,
+        sign=Sign.ARIES,
+        dignity_score=0,
+        retrograde=False,
+        speed=0.5,
+    )
+
+    aspect_info = {"degrees_to_exact": 5.0}
+    days_to_perfect = aspect_info["degrees_to_exact"] / abs(pos1.speed - pos2.speed)
+
+    now = datetime.datetime.utcnow()
+    chart = HoraryChart(
+        date_time=now,
+        date_time_utc=now,
+        timezone_info="UTC",
+        location=(0.0, 0.0),
+        location_name="Test",
+        planets={Planet.MARS: pos1, Planet.VENUS: pos2},
+        aspects=[],
+        houses=[0.0] * 12,
+        house_rulers={1: Planet.MARS, 7: Planet.VENUS},
+        ascendant=0.0,
+        midheaven=0.0,
+        julian_day=0.0,
+    )
+
+    def fake_station_time(planet_id, jd_start, max_days=365):
+        return jd_start + days_to_perfect + extra_days
+
+    monkeypatch.setattr(engine_module, "calculate_next_station_time", fake_station_time)
+
+    assert engine._enhanced_perfects_in_sign(pos1, pos2, aspect_info, chart)
+


### PR DESCRIPTION
## Summary
- Predict next station using Swiss Ephemeris and compare with aspect perfection timing
- Avoid denying perfection when station occurs after the aspect perfects
- Add property-based test ensuring post-perfection stations don't trigger denial

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ef00aa9088324ac01e931f85b57bf