### PR TITLE
Refine Moon next aspect handling

### DIFF
--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -1499,26 +1499,21 @@ class EnhancedTraditionalHoraryJudgmentEngine:
         
         # 3.6. PRIORITY: Check Moon's next applying aspect to significators (traditional key indicator)
         moon_next_aspect_result = self._check_moon_next_aspect_to_significators(chart, querent_planet, quesited_planet, ignore_void_moon)
-        if moon_next_aspect_result["decisive"]:
-            if moon_next_aspect_result["result"] == "NO":
-                return {
-                    "result": "NO",
-                    "confidence": moon_next_aspect_result["confidence"],
-                    "reasoning": reasoning + [f"Moon's next aspect denies perfection: {moon_next_aspect_result['reason']}"],
-                    "timing": moon_next_aspect_result["timing"],
-                    "traditional_factors": {
-                        "perfection_type": "moon_next_aspect",
-                        "reception": moon_next_aspect_result.get("reception", "none"),
-                        "querent_strength": chart.planets[querent_planet].dignity_score,
-                        "quesited_strength": chart.planets[quesited_planet].dignity_score,
-                        "moon_void": moon_next_aspect_result.get("void_moon", False)
-                    },
-                    "solar_factors": solar_factors
-                }
-            else:
-                reasoning.append(
-                    f"Moon's next aspect supports but cannot perfect: {moon_next_aspect_result['reason']}"
-                )
+        # Only decisive if no other perfection exists
+        if perfection.get("perfects"):
+            moon_next_aspect_result["decisive"] = False
+
+        # Append Moon's testimony and adjust confidence instead of returning early
+        if moon_next_aspect_result["result"] == "NO":
+            reasoning.append(
+                f"Moon's next aspect denies perfection: {moon_next_aspect_result['reason']}"
+            )
+            confidence = min(confidence, moon_next_aspect_result["confidence"])
+        else:
+            reasoning.append(
+                f"Moon's next aspect supports but cannot perfect: {moon_next_aspect_result['reason']}"
+            )
+            confidence = min(confidence, moon_next_aspect_result["confidence"])
         
         # 3.7. Enhanced Moon testimony analysis when no decisive Moon aspect
         moon_testimony = self._check_enhanced_moon_testimony(chart, querent_planet, quesited_planet, ignore_void_moon)

--- a/backend/tests/test_moon_next_aspect_invariant.py
+++ b/backend/tests/test_moon_next_aspect_invariant.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+from horary_engine import engine as engine_module
+from horary_engine.engine import EnhancedTraditionalHoraryJudgmentEngine
+from test_consideration_warnings import make_chart, patch_engine_for_tests
+
+
+def test_direct_perfection_not_overridden_by_unfavorable_moon(monkeypatch):
+    engine = EnhancedTraditionalHoraryJudgmentEngine()
+    patch_engine_for_tests(engine, monkeypatch)
+
+    chart = make_chart()
+    monkeypatch.setattr(
+        engine_module,
+        "check_enhanced_radicality",
+        lambda c, ignore=False: {"valid": True, "reason": "radical"},
+    )
+    monkeypatch.setattr(
+        engine,
+        "_is_moon_void_of_course_enhanced",
+        lambda c: {"void": False, "exception": False, "reason": ""},
+    )
+
+    def fake_moon_next_aspect(*args, **kwargs):
+        return {
+            "decisive": True,
+            "result": "NO",
+            "confidence": 60,
+            "reason": "Moon square Mercury",
+            "timing": "1 day",
+            "reception": "none",
+            "void_moon": False,
+        }
+
+    monkeypatch.setattr(
+        engine, "_check_moon_next_aspect_to_significators", fake_moon_next_aspect
+    )
+
+    result = engine._apply_enhanced_judgment(chart, {})
+
+    assert result["result"] == "YES"


### PR DESCRIPTION
## Summary
- Integrate Moon's next aspect into reasoning instead of early returning and cap decisiveness when other perfections exist
- Ensure Moon's next aspect cannot override direct perfection with new invariant test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ef01078d8832487122db536eec4ad