### PR TITLE
Add weighted rule schema and validation

### DIFF
--- a/backend/rule_dump.py
+++ b/backend/rule_dump.py
@@ -1,0 +1,35 @@
+from typing import Any, Dict, List
+
+import rules
+
+
+def _resolve_weight(rule: Dict[str, Any]) -> float:
+    """Resolve the weight for a rule."""
+    if isinstance(rule.get("weight"), (int, float)):
+        return float(rule["weight"])
+
+    fn_name = rule.get("weight_fn")
+    if fn_name:
+        fn = getattr(rules, fn_name, None)
+        if callable(fn):
+            return float(fn())
+        raise ValueError(f"Weight function '{fn_name}' not found")
+
+    raise ValueError(f"Rule '{rule.get('id')}' lacks a weight or weight_fn")
+
+
+def dump_rules() -> List[Dict[str, Any]]:
+    """Return a list of rules with resolved numeric weights."""
+    dumped: List[Dict[str, Any]] = []
+    for rule in rules.RULES:
+        weight = _resolve_weight(rule)
+        dumped.append({**{k: v for k, v in rule.items() if k != "weight_fn"}, "weight": weight})
+    return dumped
+
+
+def apply_rule(rule_id: str, value: float) -> float:
+    """Apply a rule's weight to a value."""
+    for rule in dump_rules():
+        if rule.get("id") == rule_id:
+            return value * rule["weight"]
+    raise KeyError(f"Unknown rule id: {rule_id}")

--- a/backend/rules.py
+++ b/backend/rules.py
@@ -1,0 +1,29 @@
+from typing import List, Dict, Optional
+
+def dynamic_weight() -> float:
+    """Example weight function used by some rules.
+
+    In real usage this could compute a weight based on
+    external configuration or runtime context. For the
+    test suite we simply return a deterministic value.
+    """
+    return 2.5
+
+
+# Rules use a common schema where each rule must provide either a
+# numeric ``weight`` or a callable name via ``weight_fn``.
+#
+# The schema is intentionally simple to keep the rule system flexible
+# while allowing unit tests to validate the structure.
+RULES: List[Dict[str, Optional[str]]] = [
+    {
+        "id": "static",
+        "description": "Rule with an inline numeric weight",
+        "weight": 1.0,
+    },
+    {
+        "id": "dynamic",
+        "description": "Rule that resolves its weight via a named function",
+        "weight_fn": "dynamic_weight",
+    },
+]

--- a/backend/tests/test_rule_weights.py
+++ b/backend/tests/test_rule_weights.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+# Ensure modules in parent directory are importable
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import rules
+from rule_dump import dump_rules, apply_rule
+
+
+def test_rules_have_weight_or_fn():
+    """Every rule must define a numeric weight or a weight function."""
+    for rule in rules.RULES:
+        has_numeric = isinstance(rule.get('weight'), (int, float))
+        has_fn = isinstance(rule.get('weight_fn'), str)
+        assert has_numeric or has_fn, f"Rule {rule.get('id')} missing weight or weight_fn"
+        if has_fn:
+            assert hasattr(rules, rule['weight_fn']), f"Missing weight function {rule['weight_fn']}"
+
+
+def test_dump_resolves_weights_and_consumer_works():
+    dumped = dump_rules()
+    weight_map = {r['id']: r['weight'] for r in dumped}
+
+    # All weights should be numeric after dumping
+    for w in weight_map.values():
+        assert isinstance(w, (int, float))
+
+    # Consumer should apply weights correctly
+    assert apply_rule('static', 10) == 10 * weight_map['static']
+    assert apply_rule('dynamic', 10) == 10 * weight_map['dynamic']


### PR DESCRIPTION
## Summary
- introduce RULES schema supporting numeric weights or weight functions
- provide rule dump utilities that resolve numeric weight or invoke functions
- add tests verifying rule weight schema and consumer behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ef02bbb108324aa71736396be15a7