### PR TITLE
Refine solar combustion penalties with optional extreme denial

### DIFF
--- a/backend/horary_constants.yaml
+++ b/backend/horary_constants.yaml
@@ -38,6 +38,7 @@ orbs:
   cazimi_orb_arcmin: 17  # arcminutes
   combustion_orb: 8.5    # degrees
   under_beams_orb: 15.0  # degrees
+  extreme_combustion_arcmin: 60  # arcminutes for denial gating
   
   # Void-of-course orbs by method
   void_orb_deg: 1.0  # for "by_orb" method
@@ -163,7 +164,7 @@ retrograde:
   quesited_penalty: 12    # Confidence penalty for retrograde quesited (mitigable)
 
 solar:
-  severe_impediment_denial_enabled: false  # R17b toggle for severe combustion denial
+  extreme_combustion_denial_enabled: false  # Toggle for extreme combustion denial
 
 reception:
   terms:

--- a/backend/horary_constants_backup_20250813_140931.yaml
+++ b/backend/horary_constants_backup_20250813_140931.yaml
@@ -28,6 +28,7 @@ orbs:
   cazimi_orb_arcmin: 17  # arcminutes
   combustion_orb: 8.5    # degrees
   under_beams_orb: 15.0  # degrees
+  extreme_combustion_arcmin: 60  # arcminutes for denial gating
   
   # Void-of-course orbs by method
   void_orb_deg: 1.0  # for "by_orb" method
@@ -136,7 +137,11 @@ dignity:
   cadent: -1
 
 # Retrograde handling
-retrograde:
-  automatic_denial: false  # Don't automatically deny for retrograde
-  dignity_penalty: -2     # Penalty for retrograde significator
-  frustration_penalty: -5 # Additional penalty for retrograde frustration
+  retrograde:
+    automatic_denial: false  # Don't automatically deny for retrograde
+    dignity_penalty: -2     # Penalty for retrograde significator
+    frustration_penalty: -5 # Additional penalty for retrograde frustration
+    quesited_penalty: 12    # Confidence penalty for retrograde quesited (mitigable)
+
+solar:
+  extreme_combustion_denial_enabled: false  # Toggle for extreme combustion denial

--- a/backend/rules.py
+++ b/backend/rules.py
@@ -26,4 +26,10 @@ RULES: List[Dict[str, Optional[str]]] = [
         "description": "Rule that resolves its weight via a named function",
         "weight_fn": "dynamic_weight",
     },
+    {
+        "id": "solar_extreme_combustion_denial",
+        "description": "Denial for unsupported cadent planet under extreme combustion",
+        "weight": 1.0,
+        "gating": False,
+    },
 ]

--- a/backend/tests/test_mutual_reception_no_connection.py
+++ b/backend/tests/test_mutual_reception_no_connection.py
@@ -66,9 +66,18 @@ def test_mutual_reception_without_connection(monkeypatch):
     monkeypatch.setattr(engine, "_apply_dignity_confidence_adjustment", lambda c, ch, q, qs, r: c)
     monkeypatch.setattr(engine, "_apply_retrograde_quesited_penalty", lambda c, ch, q, r: c)
     monkeypatch.setattr(engine, "_calculate_enhanced_timing", lambda *a, **k: None)
-    monkeypatch.setattr(engine, "_check_enhanced_moon_testimony", lambda *a, **k: {})
+    monkeypatch.setattr(engine, "_check_enhanced_moon_testimony", lambda *a, **k: {"reason": "", "aspects": []})
     monkeypatch.setattr(engine, "_check_enhanced_denial_conditions", lambda *a, **k: {"denied": False})
-    monkeypatch.setattr(engine, "_check_moon_next_aspect_to_significators", lambda *a, **k: {"decisive": False})
+    monkeypatch.setattr(
+        engine,
+        "_check_moon_next_aspect_to_significators",
+        lambda *a, **k: {
+            "decisive": False,
+            "result": "YES",
+            "reason": "",
+            "confidence": 100,
+        },
+    )
     monkeypatch.setattr(engine, "_check_benefic_aspects_to_significators", lambda *a, **k: {"favorable": False})
 
     perfection = engine._check_enhanced_perfection(chart, Planet.MERCURY, Planet.JUPITER)

--- a/backend/tests/test_rule_weights.py
+++ b/backend/tests/test_rule_weights.py
@@ -29,3 +29,8 @@ def test_dump_resolves_weights_and_consumer_works():
     # Consumer should apply weights correctly
     assert apply_rule('static', 10) == 10 * weight_map['static']
     assert apply_rule('dynamic', 10) == 10 * weight_map['dynamic']
+
+
+def test_extreme_combustion_rule_gating_default_false():
+    rule = next(r for r in rules.RULES if r['id'] == 'solar_extreme_combustion_denial')
+    assert rule.get('gating') is False


### PR DESCRIPTION
## Summary
- Distinguish under-beams and combustion penalties in solar analysis
- Add config-gated extreme combustion denial for unsupported cadent planets
- Document new rule catalog entry for extreme combustion gating

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eff01224883249ffb6752a107bb00