### PR TITLE
Add angularity and end-of-matter support modifiers

### DIFF
--- a/backend/non_gating_modifiers.md
+++ b/backend/non_gating_modifiers.md
@@ -1,0 +1,6 @@
+# Non-Gating Rule Modifiers
+
+The following rule identifiers adjust confidence but do not determine the final judgment:
+
+- `END_OF_MATTER_SUPPORT` – applies a small bonus when the ruler of the 4th house favors the querent or the Moon through aspect or reception.
+- `SIGNIFICATOR_ANGULARITY` – modifies confidence based on whether significators occupy angular, succedent, or cadent houses.

--- a/backend/tests/test_consideration_warnings.py
+++ b/backend/tests/test_consideration_warnings.py
@@ -78,6 +78,10 @@ def test_non_radical_chart_still_returns(monkeypatch):
         cfg().confidence.base_confidence - cfg().radicality.asc_warning_penalty,
         cfg().confidence.perfection.direct_basic,
     )
+    modifiers = engine._evaluate_significator_angularity(chart, Planet.MERCURY, Planet.JUPITER)
+    expected_confidence = max(0, min(expected_confidence + modifiers["delta"], 100))
+    end_support = engine._evaluate_end_of_matter_support(chart, Planet.MERCURY)
+    expected_confidence = max(0, min(expected_confidence + end_support["bonus"], 100))
     assert result["confidence"] == expected_confidence
 
 
@@ -94,5 +98,10 @@ def test_void_moon_chart_still_returns(monkeypatch):
 
     assert result["result"] == "YES"
     assert any("Void Moon" in r for r in result["reasoning"])
-    assert result["confidence"] == cfg().confidence.lunar_confidence_caps.neutral
+    expected_confidence = cfg().confidence.lunar_confidence_caps.neutral
+    modifiers = engine._evaluate_significator_angularity(chart, Planet.MERCURY, Planet.JUPITER)
+    expected_confidence = max(0, min(expected_confidence + modifiers["delta"], 100))
+    end_support = engine._evaluate_end_of_matter_support(chart, Planet.MERCURY)
+    expected_confidence = max(0, min(expected_confidence + end_support["bonus"], 100))
+    assert result["confidence"] == expected_confidence
 

--- a/backend/tests/test_solar_impediments.py
+++ b/backend/tests/test_solar_impediments.py
@@ -94,6 +94,10 @@ def test_under_beams_penalty_applied(monkeypatch):
     assert result["result"] == "YES"
     assert any("under beams" in r.lower() for r in result["reasoning"])
     expected_confidence = cfg().confidence.base_confidence - cfg().confidence.solar.under_beams_penalty
+    modifiers = engine._evaluate_significator_angularity(chart, Planet.MERCURY, Planet.JUPITER)
+    expected_confidence = max(0, min(expected_confidence + modifiers["delta"], 100))
+    end_support = engine._evaluate_end_of_matter_support(chart, Planet.MERCURY)
+    expected_confidence = max(0, min(expected_confidence + end_support["bonus"], 100))
     assert result["confidence"] == expected_confidence
 
 


### PR DESCRIPTION
## Summary
- adjust confidence using angular/succedent/cadent placement of significators
- add 4th house ruler support bonus via aspect or reception
- document END_OF_MATTER_SUPPORT and SIGNIFICATOR_ANGULARITY as non-gating rule IDs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eff10f4d4832495b6e0c0dde5d8b1