### PR TITLE
Disable gating for early ascendant and void moon

### DIFF
--- a/backend/horary_constants.yaml
+++ b/backend/horary_constants.yaml
@@ -68,6 +68,8 @@ moon:
   
   # Void-of-course configuration
   void_rule: "by_sign"  # "by_sign", "by_orb", "lilly"
+  void_gating: false  # R26 gating disabled in favor of confidence penalty
+  void_penalty: 10    # Confidence penalty applied when Moon is void-of-course
   void_exceptions:
     cancer: true     # Moon in Cancer not void even without aspects
     sagittarius: true # Moon in Sagittarius not void (traditional joy)
@@ -125,6 +127,7 @@ confidence:
 
 radicality:
   # Radicality checking parameters
+  gating: false  # R1 gating disabled in favor of confidence penalty
   asc_too_early: 3.0    # degrees
   asc_too_late: 27.0    # degrees
   saturn_7th_enabled: true  # check Saturn in 7th

--- a/backend/tests/test_consideration_warnings.py
+++ b/backend/tests/test_consideration_warnings.py
@@ -74,9 +74,8 @@ def test_non_radical_chart_still_returns(monkeypatch):
 
     assert result["result"] == "YES"
     assert any("Ascendant" in r for r in result["reasoning"])
-    expected_confidence = min(
-        cfg().confidence.base_confidence - cfg().radicality.asc_warning_penalty,
-        cfg().confidence.perfection.direct_basic,
+    expected_confidence = (
+        cfg().confidence.perfection.direct_basic - cfg().radicality.asc_warning_penalty
     )
     assert result["confidence"] == expected_confidence
 
@@ -94,5 +93,8 @@ def test_void_moon_chart_still_returns(monkeypatch):
 
     assert result["result"] == "YES"
     assert any("Void Moon" in r for r in result["reasoning"])
-    assert result["confidence"] == cfg().confidence.lunar_confidence_caps.neutral
+    expected_confidence = (
+        cfg().confidence.perfection.direct_basic - cfg().moon.void_penalty
+    )
+    assert result["confidence"] == expected_confidence
 


### PR DESCRIPTION
## Summary
- add config flags for R1 and R26 so they no longer gate judgment and instead apply penalties
- apply consideration penalties after perfection in the horary engine
- adjust consideration tests to assert reduced confidence, not automatic denials

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f189601308324a1159b5250d64b25